### PR TITLE
Fix pinheader in 3d view

### DIFF
--- a/lib/jscad-implementation-types.ts
+++ b/lib/jscad-implementation-types.ts
@@ -5,11 +5,11 @@ export interface JscadImplementation<ShapeOrOp = any, MeasurementT = number> {
     intersect: (...geometries: ShapeOrOp[]) => ShapeOrOp
     subtract: (...geometries: ShapeOrOp[]) => ShapeOrOp
     union: (...geometries: ShapeOrOp[]) => ShapeOrOp
-  },
+  }
   hulls: {
-    hull: (...geometries: ShapeOrOp[]) => ShapeOrOp
-    hullChain: (...geometries: ShapeOrOp[]) => ShapeOrOp
-  },
+    hull: (...geometries: (ShapeOrOp | ShapeOrOp[])[]) => ShapeOrOp
+    hullChain: (...geometries: (ShapeOrOp | ShapeOrOp[])[]) => ShapeOrOp
+  }
   colors: {
     colorize: (color: Color, ...geometries: ShapeOrOp[]) => ShapeOrOp
   }

--- a/lib/jscad-planner.ts
+++ b/lib/jscad-planner.ts
@@ -23,13 +23,17 @@ export const jscadPlanner: JscadImplementation<JscadOperation, JscadOperation> =
       }),
     },
     hulls: {
-      hull: (...shapes: JscadOperation[]): JscadOperation => ({
+      hull: (
+        ...shapes: (JscadOperation | JscadOperation[])[]
+      ): JscadOperation => ({
         type: "hull",
-        shapes,
+        shapes: shapes.flat(),
       }),
-      hullChain: (...shapes: JscadOperation[]): JscadOperation => ({
+      hullChain: (
+        ...shapes: (JscadOperation | JscadOperation[])[]
+      ): JscadOperation => ({
         type: "hullChain",
-        shapes,
+        shapes: shapes.flat(),
       }),
     },
     colors: {
@@ -71,7 +75,9 @@ export const jscadPlanner: JscadImplementation<JscadOperation, JscadOperation> =
         type: "polygon" as const,
         ...options,
       }),
-      cuboid: (options: { size: [number, number, number] }): JscadOperation => ({
+      cuboid: (options: {
+        size: [number, number, number]
+      }): JscadOperation => ({
         type: "cuboid",
         ...options,
       }),

--- a/tests/hull.test.ts
+++ b/tests/hull.test.ts
@@ -9,5 +9,10 @@ it("should be able to hull shapes", () => {
     type: "hull",
     shapes: [shape1, shape2],
   })
+
+  const hullShape2 = jscadPlanner.hulls.hull([shape1, shape2])
+  expect(hullShape2).toEqual({
+    type: "hull",
+    shapes: [shape1, shape2],
+  })
 })
- 


### PR DESCRIPTION
The hull plan can have an array of operations in its shapes, but the plan executioner doesn't throws an error when the input is an array. The solution is to either flatten the shapes in the jscad plan or in the execution, here I went with the former.

Before
![image](https://github.com/user-attachments/assets/fb3febd1-b790-4197-94b1-b1185bbaa3e4)

After
![image](https://github.com/user-attachments/assets/7217c418-c4ab-4848-ba77-318dc8a7280a)

closes tscircuit/3d-viewer#45
/claim tscircuit/3d-viewer#45