### PR TITLE
Implement cuboid with center support

### DIFF
--- a/lib/jscad-implementation-types.ts
+++ b/lib/jscad-implementation-types.ts
@@ -33,7 +33,10 @@ export interface JscadImplementation<ShapeOrOp = any, MeasurementT = number> {
       points: Vector2D[] | Vector2D[][]
       paths?: number[] | number[][]
     }) => ShapeOrOp
-    cuboid: (options: { size: [number, number, number] }) => ShapeOrOp
+    cuboid: (options: {
+      size: [number, number, number]
+      center?: Vector3D
+    }) => ShapeOrOp
     roundedCuboid: (options: {
       size: [number, number, number]
       roundRadius: number

--- a/lib/jscad-operations-types.ts
+++ b/lib/jscad-operations-types.ts
@@ -165,6 +165,7 @@ export interface RadToDegOperation extends OperationBase {
 export interface CuboidOperation extends OperationBase {
   type: "cuboid"
   size: [number, number, number]
+  center?: Vector3D
 }
 
 export interface RoundedCuboidOperation extends OperationBase {

--- a/lib/jscad-planner.ts
+++ b/lib/jscad-planner.ts
@@ -77,6 +77,7 @@ export const jscadPlanner: JscadImplementation<JscadOperation, JscadOperation> =
       }),
       cuboid: (options: {
         size: [number, number, number]
+        center?: Vector3D
       }): JscadOperation => ({
         type: "cuboid",
         ...options,

--- a/tests/cuboid.test.ts
+++ b/tests/cuboid.test.ts
@@ -1,0 +1,50 @@
+import { expect, it, describe } from "bun:test"
+import { jscadPlanner } from "../lib/jscad-planner.ts"
+import { executeJscadOperations } from "../lib/execute-jscad-operations.ts"
+
+describe("cuboid", () => {
+  it("should be able to create a cuboid operation", () => {
+    const cuboidOp = jscadPlanner.primitives.cuboid({
+      size: [10, 20, 5],
+    })
+
+    expect(cuboidOp).toEqual({
+      type: "cuboid",
+      size: [10, 20, 5],
+    })
+
+    const executedOp = executeJscadOperations(jscadPlanner, cuboidOp)
+    expect(executedOp).toEqual(cuboidOp)
+  })
+
+  it("should be able to create a cuboid with center", () => {
+    const cuboidOp = jscadPlanner.primitives.cuboid({
+      size: [10, 20, 5],
+      center: [1, 2, 3],
+    })
+
+    expect(cuboidOp).toEqual({
+      type: "cuboid",
+      size: [10, 20, 5],
+      center: [1, 2, 3],
+    })
+
+    const executedOp = executeJscadOperations(jscadPlanner, cuboidOp)
+    expect(executedOp).toEqual(cuboidOp)
+  })
+
+  it("should be able to use cuboid in boolean operations", () => {
+    const result = jscadPlanner.booleans.subtract(
+      jscadPlanner.primitives.cuboid({ size: [10, 10, 10] }),
+      jscadPlanner.primitives.sphere({ radius: 5 }),
+    )
+
+    expect(result).toEqual({
+      type: "subtract",
+      shapes: [
+        { type: "cuboid", size: [10, 10, 10] },
+        { type: "sphere", radius: 5 },
+      ],
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add optional `center` property to `CuboidOperation` type, matching the pattern used by other primitives (`cube`, `sphere`, `cylinder`)
- Update `JscadImplementation` interface and `jscadPlanner` to accept `center` in cuboid options
- Add comprehensive tests for cuboid: basic creation, center support, and usage in boolean operations

Closes #2